### PR TITLE
Resolve issue of git clone

### DIFF
--- a/.sqa/config.yml
+++ b/.sqa/config.yml
@@ -1,13 +1,7 @@
-config:
-  project_repos:
-    udocker:
-      repo: 'https://github.com/MartaCastro/udocker.git'
-      branch: devel-jpl 
-
 environment:
   JPL_WORKSPACEDEBUG: "true"
   JPL_WORKSPACEDEBUGTIMEOUT: 90
-  
+
 sqa_criteria:
    qc_style:
      repos:
@@ -16,7 +10,7 @@ sqa_criteria:
          tox:
            tox_file: /udocker/tox.ini
            testenv:
-              - pylint            
+              - pylint
    qc_security:
      repos:
        udocker:
@@ -24,7 +18,7 @@ sqa_criteria:
          tox:
            tox_file: /udocker/tox.ini
            testenv:
-              - bandit         
+              - bandit
    qc_coverage:
      repos:
        udocker:

--- a/.sqa/docker-compose.yml
+++ b/.sqa/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.7"
+version: "3.7"
 
 services:
   udocker-testing:

--- a/.sqa/docker-compose.yml
+++ b/.sqa/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     container_name: "udocker-testing"
     volumes:
       - type: bind
-        source: ./udocker
+        source: ./
         target: /udocker
-    
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,11 @@ pipeline {
                     buildStages(projectConfig)
                 }
              }
+             post {
+                cleanup {
+                      cleanWs()
+                }
+              }
         }
    }
 }


### PR DESCRIPTION
There is already a symlink udocker inside triggered repository defined for Jenkins pipeline.
Instead of cloning again the same repository you can use directly the already cloned repository in the workspace.
I also add with this PR the Jenkins workspace cleanup as a post action and correct docker-compose.yml version to a supported one.